### PR TITLE
fix: update Kivy and Pillow dependencies for Python 3.12/3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 watchdog
-Kivy~=2.2.0
+Kivy>=2.3.0
 kivymd @ https://github.com/kivymd/KivyMD/archive/a85adc5ee4ee2178b7d353a260f2cbcefce885c7.zip
 pygame
-Pillow~=9.4.0
+Pillow>=10.0.0
 requests~=2.28.2
 multitasking~=0.0.11
 javaobj-py3==0.4.3


### PR DESCRIPTION
This PR updates Kivy and Pillow dependencies to resolve compatibility issues with Python 3.12 and 3.13.

## Changes

- **Kivy**: Updated from `~=2.2.0` to `>=2.3.0` to fix compatibility with `kivy_deps.sdl2_dev` (version 0.6.0 is no longer available, only 0.7.0+)
- **Pillow**: Updated from `~=9.4.0` to `>=10.0.0` to support Python 3.13

## Problem Solved

Resolves issue #4 where installation was failing with:
- `ERROR: Could not find a version that satisfies the requirement kivy_deps.sdl2_dev~=0.6.0`
- Error building Pillow 9.4.0 on Python 3.13

Resolves #4